### PR TITLE
fix: fix TS type generator to merge type for protocol right

### DIFF
--- a/messgen/ts_generator.py
+++ b/messgen/ts_generator.py
@@ -71,7 +71,8 @@ class TypeScriptGenerator:
         types = set()
         code = []
 
-        for proto_name, proto_def in protocols.items():
+        for proto_def in protocols.values():
+            proto_name = proto_def.name
             code.append(f"export interface {self._to_camel_case(proto_name)} {{")
             code.append(f"  '{proto_name}': {{")
             for message in proto_def.messages.values():
@@ -83,7 +84,7 @@ class TypeScriptGenerator:
             code.append('')
 
         import_statements = self._generate_protocol_imports(types)
-        protocol_types = ' | '.join(self._to_camel_case(proto_name) for proto_name in protocols.keys())
+        protocol_types = ' & '.join(self._to_camel_case(proto_name) for proto_name in protocols.keys())
         final_code = '\n'.join(import_statements + code) + f'export type Protocol = {protocol_types};'
 
 
@@ -92,7 +93,7 @@ class TypeScriptGenerator:
     def _generate_protocol_imports(self, types: set[str]) -> list[str]:
         import_statements = ["import type {"]
         for struct_name in types:
-            import_statements.append(f"    {struct_name},")
+            import_statements.append(f"  {struct_name},")
         import_statements.append("} from './types';")
         import_statements.append('')
         return import_statements

--- a/port/js/package-lock.json
+++ b/port/js/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "messgen",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messgen",
-      "version": "0.0.7",
+      "version": "0.0.9",
+      "dependencies": {
+        "messgen": "0.0.9"
+      },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",
         "@types/node": "^20.12.7",
@@ -4880,6 +4883,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/messgen": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/messgen/-/messgen-0.0.9.tgz",
+      "integrity": "sha512-WTTa+fEdwZK/+6lueFAdeIzI6FElDkzt/+Rv8YX7BCaWCITGxZwWrOsbalKd/AeuTLztiOY8fhpR/7QfB1EPAw=="
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/port/js/package.json
+++ b/port/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messgen",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "scripts": {
     "build": "bunchee",
     "test": "vitest",

--- a/port/js/src/Codec.ts
+++ b/port/js/src/Codec.ts
@@ -1,10 +1,10 @@
 import { type RawType, type Protocol, Protocols } from './protocol';
 import { type Converter, ConverterFactory } from './converters';
-import type { ExtractPayload, GenericConfig, TypeToIdMap, TypeToNameMap } from './Codec.types';
+import type { ExtractPayload, TypeToIdMap, TypeToNameMap } from './Codec.types';
 import { Buffer } from './Buffer';
 import type { ProtocolId, MessageId } from './types';
 
-export class Codec<Config extends GenericConfig = GenericConfig> {
+export class Codec<Config extends object = object> {
   private typesByName: TypeToNameMap = new Map();
   private typesById: TypeToIdMap = new Map();
   private protocols = new Protocols();

--- a/port/js/src/Codec.types.ts
+++ b/port/js/src/Codec.types.ts
@@ -3,12 +3,11 @@
 import type { Converter } from './converters/Converter';
 import type { MessageId, ProtocolId, ProtocolName } from './types';
 
-export type GenericConfig = Record<string, Record<string, any>>;
 export type TypeToNameMap = Map<ProtocolName, Map<string, Converter>>;
 export type TypeToIdMap = Map<ProtocolId, Map<MessageId, Converter>>;
 
 export type ExtractPayload<
-  Schema extends Record<string, Record<string, any>>,
+  Schema extends object,
   Name extends keyof Schema,
   MessageType extends keyof Schema[Name],
 > = Schema[Name][MessageType];

--- a/port/js/src/Protocols.test.ts
+++ b/port/js/src/Protocols.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Protocols } from './protocol/Protocols';
+
+describe('Protocols', () => {
+  let protocols: Protocols;
+
+  beforeAll(() => {
+    protocols = new Protocols();
+    protocols.load([
+      {
+        type: 'simple_struct',
+        type_class: '8',
+        fields: [
+          { name: 'f0', type: 'uint64' },
+          { name: 'f1', type: 'int64' },
+        ],
+      },
+      {
+        type: 'simple_enum',
+        type_class: '7',
+        base_type: 'uint8',
+        values: [
+          { name: 'one_value', value: 0 },
+          { name: 'another_value', value: 1 },
+        ],
+      },
+    ]);
+  });
+
+  describe('#getType', () => {
+    it('should resolve scalar types', () => {
+      const type = protocols.getType('uint64');
+      expect(type).toEqual({
+        type: 'uint64',
+        typeClass: 'scalar',
+      });
+    });
+
+    it('should resolve array types', () => {
+      const type = protocols.getType('uint64[4]');
+      expect(type).toEqual({
+        type: 'uint64[4]',
+        typeClass: 'typed-array',
+        elementType: 'uint64',
+        arraySize: 4,
+      });
+    });
+
+    it('should resolve dynamic array types', () => {
+      const type = protocols.getType('uint64[]');
+      expect(type).toEqual({
+        type: 'uint64[]',
+        typeClass: 'typed-array',
+        elementType: 'uint64',
+        size: undefined,
+      });
+    });
+
+    it('should resolve map types', () => {
+      const type = protocols.getType('string{int32}');
+      expect(type).toEqual({
+        type: 'string{int32}',
+        typeClass: 'map',
+        keyType: 'int32',
+        valueType: 'string',
+      });
+    });
+
+    it('should resolve struct types', () => {
+      const type = protocols.getType('simple_struct');
+      expect(type).toEqual({
+        typeClass: 'struct',
+        typeName: 'simple_struct',
+        fields: [
+          { name: 'f0', type: 'uint64' },
+          { name: 'f1', type: 'int64' },
+        ],
+      });
+    });
+
+    it('should resolve enum types', () => {
+      const type = protocols.getType('simple_enum');
+      expect(type).toEqual({
+        typeClass: 'enum',
+        typeName: 'simple_enum',
+        type: 'uint8',
+        values: [
+          { name: 'one_value', value: 0 },
+          { name: 'another_value', value: 1 },
+        ],
+      });
+    });
+
+    it('should throw error for unknown types', () => {
+      expect(() => {
+        protocols.getType('unknown_type');
+      }).toThrow('Unknown type: unknown_type not found');
+    });
+
+    it('should resolve cross-protocol type references', () => {
+      const type = protocols.getType('simple_struct');
+      expect(type).toBeDefined();
+      expect(type.typeClass).toBe('struct');
+    });
+  });
+});


### PR DESCRIPTION
- fix TS type helper interface merging (add '&' instead of '|') to combine types instead of an empty set
- fix TS generator extra space for types import
- add few test specs for Protocol class
- fixed TS type hint for protocol name for codec helper
- remove protocol prefix from the TS generated type names