### PR TITLE
Use composition instead of inheritance for messages

### DIFF
--- a/messgen/common.p
+++ b/messgen/common.p
@@ -185,7 +185,7 @@ class CppGenerator:
                 if proto_id is not None:
                     code.append(f"    constexpr static inline int16_t PROTO_ID = {proto_id};")
 
-                code.extend(self._generate_messages(proto_name, class_name, proto_def))
+                code.extend(self._generate_messages(namespace_name, class_name, proto_def))
                 code.extend(self._generate_reflect_message_decl())
                 code.extend(self._generate_dispatcher_decl())
 
@@ -196,7 +196,7 @@ class CppGenerator:
 
         return self._PREAMBLE_HEADER + self._generate_includes() + code
 
-    def _generate_messages(self, proto_name: str, class_name: str, proto_def: Protocol):
+    def _generate_messages(self, namespace_name: str, class_name: str, proto_def: Protocol):
         self._add_include("tuple")
         code: list[str] = []
         for message in proto_def.messages.values():
@@ -210,7 +210,7 @@ class CppGenerator:
                             constexpr inline static int16_t PROTO_ID = protocol_type::PROTO_ID;
                             constexpr inline static int16_t MESSAGE_ID = {message.message_id};
                             constexpr inline static uint64_t HASH = {hash_message(message)}ULL ^ data_type::HASH;
-                            constexpr inline static const char* NAME = "{_qual_name(proto_name)}::{message.name}";
+                            constexpr inline static const char* NAME = "{namespace_name}::{message.name}";
 
                             auto operator<=>(const {message.name} &) const = default;
 

--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -209,6 +209,7 @@ class CppGenerator:
                             constexpr inline static int16_t PROTO_ID = protocol_type::PROTO_ID;
                             constexpr inline static int16_t MESSAGE_ID = {message.message_id};
                             constexpr inline static uint64_t HASH = {hash_message(message)}ULL ^ data_type::HASH;
+                            constexpr inline static const char* NAME = "{_qual_name(class_name)}::{message.name}";
                         }};"""),
                     "    ",
                 ).splitlines()
@@ -392,9 +393,9 @@ class CppGenerator:
             is_flat_str = "true"
         code.append(_indent(f"constexpr static inline bool IS_FLAT = {is_flat_str};"))
         if type_hash := hash_type(type_def, types):
-            code.append(_indent(f"constexpr static inline uint64_t HASH = {type_hash}ULL;"))
-        code.append(_indent(f'constexpr static inline const char* NAME = "{_qual_name(type_name)}";'))
-        code.append(_indent(f'constexpr static inline const char* SCHEMA = R"_({self._generate_schema(type_def)})_";'))
+            code.append(_indent(f"constexpr inline static uint64_t HASH = {type_hash}ULL;"))
+        code.append(_indent(f'constexpr inline static const char* NAME = "{_qual_name(type_name)}";'))
+        code.append(_indent(f'constexpr inline static const char* SCHEMA = R"_({self._generate_schema(type_def)})_";'))
         code.append("")
 
         for field in type_def.fields:

--- a/port/cpp_nostl/messgen/concepts.h
+++ b/port/cpp_nostl/messgen/concepts.h
@@ -46,6 +46,7 @@ template <class Message>
 concept message = type<typename std::remove_cvref_t<Message>::data_type> && requires(std::remove_cvref_t<Message> msg) {
     { msg.PROTO_ID } -> std::convertible_to<int>;
     { msg.MESSAGE_ID } -> std::convertible_to<int>;
+    { msg.data } -> std::convertible_to<typename std::remove_cvref_t<Message>::data_type>;
 };
 
 template <class Protocol>

--- a/port/cpp_stl/messgen/concepts.h
+++ b/port/cpp_stl/messgen/concepts.h
@@ -44,6 +44,7 @@ template <class Message>
 concept message = type<typename std::remove_cvref_t<Message>::data_type> && requires(std::remove_cvref_t<Message> msg) {
     { msg.PROTO_ID } -> std::convertible_to<int>;
     { msg.MESSAGE_ID } -> std::convertible_to<int>;
+    { msg.data } -> std::convertible_to<typename std::remove_cvref_t<Message>::data_type>;
 };
 
 template <class Protocol>

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -60,7 +60,7 @@ TEST_F(CppTest, SimpleStruct) {
         .f8 = 9,
     }};
 
-    test_serialization(msg);
+    test_serialization(msg.data);
 }
 
 TEST_F(CppTest, StructWithEnum) {
@@ -289,8 +289,8 @@ TEST_F(CppTest, DispatchMessage) {
         using ActualType = std::decay_t<decltype(actual)>;
 
         if constexpr (std::is_same_v<ActualType, test_proto::simple_struct_msg>) {
-            EXPECT_EQ(expected.f0, actual.f0);
-            EXPECT_EQ(expected.f1, actual.f1);
+            EXPECT_EQ(expected.f0, actual.data.f0);
+            EXPECT_EQ(expected.f1, actual.data.f1);
             invoked = true;
         } else {
             FAIL() << "Unexpected message type handled.";
@@ -308,7 +308,7 @@ TEST_F(CppTest, TypeConcept) {
     struct not_a_message {};
 
     EXPECT_TRUE(type<test::simple_struct>);
-    EXPECT_TRUE(type<test_proto::simple_struct_msg>);
+    EXPECT_FALSE(type<test_proto::simple_struct_msg>);
     EXPECT_FALSE(type<not_a_message>);
     EXPECT_FALSE(type<int>);
 }

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -245,6 +245,13 @@ TEST_F(CppTest, MessageReflectionFieldTypes) {
     EXPECT_EQ(expected_types, types);
 }
 
+TEST_F(CppTest, MessageReflection) {
+    using namespace messgen;
+
+    auto message = test_proto::complex_struct_msg{};
+    EXPECT_EQ("test_proto::complex_struct_msg", name_of(reflect_object(message)));
+}
+
 TEST_F(CppTest, EnumReflection) {
     using namespace messgen;
     using namespace std::literals;


### PR DESCRIPTION
Messages inheriting from types proved to be confusing.
While it less ergonomic to call msg.data.member instead
of just msg.member, it is more correct from the design
pov to have to do so.