### PR TITLE
C++: Allow field named as message / type

### DIFF
--- a/messgen/cpp_generator.py
+++ b/messgen/cpp_generator.py
@@ -212,7 +212,7 @@ class CppGenerator:
                             constexpr inline static uint64_t HASH = {hash_message(message)}ULL ^ data_type::HASH;
                             constexpr inline static const char* NAME = "{_qual_name(proto_name)}::{message.name}";
 
-                            auto operator<=>(const {message.name} &) const = default;
+                            auto operator<=>(const struct {message.name} &) const = default;
 
                             data_type data;
                         }};"""),
@@ -514,7 +514,7 @@ class CppGenerator:
         if self._get_cpp_standard() >= 20:
             # Operator <=>
             code.append("")
-            code.append(_indent("auto operator<=>(const %s &) const = default;" % unqual_name))
+            code.append(_indent("auto operator<=>(const struct %s &) const = default;" % unqual_name))
 
         code.append("};")
 
@@ -534,7 +534,7 @@ class CppGenerator:
             code.extend(
                 [
                     "",
-                    f"bool operator==(const {unqual_name}& l, const {unqual_name}& r) {{",
+                    f"bool operator==(const struct {unqual_name}& l, const struct {unqual_name}& r) {{",
                 ]
                 + _indent(code_eq)
                 + ["}"]

--- a/tests/cpp/CppTest.cpp
+++ b/tests/cpp/CppTest.cpp
@@ -6,6 +6,7 @@
 #include <messgen/test/flat_struct.h>
 #include <messgen/test/struct_with_enum.h>
 #include <messgen/test/var_size_struct.h>
+#include <messgen/test/name_clash_struct.h>
 
 #include <gtest/gtest.h>
 

--- a/tests/data/types/messgen/test/name_clash_struct.yaml
+++ b/tests/data/types/messgen/test/name_clash_struct.yaml
@@ -1,4 +1,4 @@
 type_class: struct
-comment: "Simple struct example"
+comment: "A struct with field name clashing with type name"
 fields:
   - { name: "name_clash_struct", type: "uint64", comment: "Clashing name struct" }

--- a/tests/data/types/messgen/test/name_clash_struct.yaml
+++ b/tests/data/types/messgen/test/name_clash_struct.yaml
@@ -1,0 +1,4 @@
+type_class: struct
+comment: "Simple struct example"
+fields:
+  - { name: "name_clash_struct", type: "uint64", comment: "Clashing name struct" }


### PR DESCRIPTION
This is to ensure that whenever a field is named
the same way as the enclosing message or type
the generated C++ code disambiguates correctly.