### PR TITLE
Allow inspecting the underlying in dynamic 

### DIFF
--- a/messgen/dynamic.py
+++ b/messgen/dynamic.py
@@ -1,7 +1,6 @@
 import json
 import struct
 import typing
-import sys
 
 from abc import (
     ABC,

--- a/messgen/dynamic.py
+++ b/messgen/dynamic.py
@@ -75,7 +75,10 @@ class TypeConverter(ABC):
         assert self._type_hash
         return self._type_hash
 
-    def serialize(self, data: dict) -> bytes:
+    def type_definition(self) -> MessgenType:
+        return self._type_def
+
+    def serialize(self, data: dict | Decimal) -> bytes:
         return self._serialize(data)
 
     def deserialize(self, data: bytes) -> dict:
@@ -562,6 +565,11 @@ class Codec:
             for msg_id, message in proto_def.messages.items():
                 self._id_by_name[(proto_name, message.name)] = (proto_def.proto_id, message)
                 self._name_by_id[(proto_def.proto_id, msg_id)] = (proto_name, message)
+
+    def type_definition(self, type_name: str) -> MessgenType:
+        if type_name in self._converters_by_name:
+            return self._converters_by_name[type_name].type_definition()
+        raise MessgenError(f"Unsupported type_name={type_name}")
 
     def type_converter(self, type_name: str) -> TypeConverter:
         if converter := self._converters_by_name.get(type_name):

--- a/messgen/dynamic.py
+++ b/messgen/dynamic.py
@@ -16,14 +16,14 @@ from pathlib import (
 from .model import (
     ArrayType,
     EnumType,
+    hash_message,
+    hash_type,
     MapType,
+    Message,
     MessgenType,
     StructType,
     TypeClass,
     VectorType,
-    Message,
-    hash_type,
-    hash_message,
 )
 from .yaml_parser import (
     parse_protocols,

--- a/tests/python/test_codec.py
+++ b/tests/python/test_codec.py
@@ -278,9 +278,13 @@ def test_enum_type_definition(codec):
 
     assert len(type_def.values) > 0
 
-    expected_values = ["one_value", "another_value"]
-    for value in expected_values:
-        assert any(item.name == value for item in type_def.values)
+    expected_values = [
+        (0, "one_value"),
+        (1, "another_value"),
+    ]
+    for value, name in expected_values:
+        assert any(item.name == name for item in type_def.values)
+        assert any(item.value == value for item in type_def.values)
 
 
 def test_enum_converter_serialization(codec):


### PR DESCRIPTION
For python dynamic messgen protocol we need a way to introspect
the model, i.e. to get hold of the mapping between enum and
its values.